### PR TITLE
[NSA-7586] Approver email BCC addresses bugfix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "login.dfe.jobs",
-  "version": "1.0.1",
+  "version": "1.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "login.dfe.jobs",
-      "version": "1.0.1",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@slack/webhook": "^5.0.3",
@@ -23,7 +23,7 @@
         "login.dfe.healthcheck": "git+https://github.com/DFE-Digital/login.dfe.healthcheck.git#v3.0.0",
         "login.dfe.kue": "git+https://github.com/DFE-Digital/login.dfe.kue.git#v0.11.6",
         "login.dfe.migration.admin.job": "git+https://github.com/DFE-Digital/login.dfe.migration.admin.jobs.git#v1.2.1",
-        "login.dfe.notification.jobs": "git+https://github.com/DFE-Digital/login.dfe.notifications.jobs.git#v6.3.0",
+        "login.dfe.notification.jobs": "git+https://github.com/DFE-Digital/login.dfe.notifications.jobs.git#v6.3.1",
         "login.dfe.public-api.jobs": "git+https://github.com/DFE-Digital/login.dfe.public-api.jobs.git#v2.1.0",
         "login.dfe.service-notifications.jobs": "git+https://github.com/DFE-Digital/login.dfe.service-notifications.jobs.git#v2.3.0",
         "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",
@@ -8069,8 +8069,8 @@
       }
     },
     "node_modules/login.dfe.notification.jobs": {
-      "version": "6.2.5",
-      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.notifications.jobs.git#5511bcccfd109b2747c2377568d5c5e147ef5de7",
+      "version": "6.3.1",
+      "resolved": "git+ssh://git@github.com/DFE-Digital/login.dfe.notifications.jobs.git#57f3cc1fc9d0216139bbcbd9d68b4f7118a9ef02",
       "license": "MIT",
       "dependencies": {
         "aws-sdk": "^2.279.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "login.dfe.jobs",
-  "version": "1.0.1",
+  "version": "1.3.1",
   "description": "",
   "scripts": {
     "dev": "settings='./config/login.dfe.jobs.dev.json' nodemon src/index.js",
@@ -34,7 +34,7 @@
     "login.dfe.healthcheck": "git+https://github.com/DFE-Digital/login.dfe.healthcheck.git#v3.0.0",
     "login.dfe.kue": "git+https://github.com/DFE-Digital/login.dfe.kue.git#v0.11.6",
     "login.dfe.migration.admin.job": "git+https://github.com/DFE-Digital/login.dfe.migration.admin.jobs.git#v1.2.1",
-    "login.dfe.notification.jobs": "git+https://github.com/DFE-Digital/login.dfe.notifications.jobs.git#v6.3.0",
+    "login.dfe.notification.jobs": "git+https://github.com/DFE-Digital/login.dfe.notifications.jobs.git#v6.3.1",
     "login.dfe.public-api.jobs": "git+https://github.com/DFE-Digital/login.dfe.public-api.jobs.git#v2.1.0",
     "login.dfe.service-notifications.jobs": "git+https://github.com/DFE-Digital/login.dfe.service-notifications.jobs.git#v2.3.0",
     "login.dfe.winston-appinsights": "git+https://github.com/DFE-Digital/login.dfe.winston-appinsights.git#v5.0.0",


### PR DESCRIPTION
For ticket: https://dfe-secureaccess.atlassian.net/browse/NSA-7586

- Updates login.dfe.notifications.jobs to use the [latest version](https://github.com/DFE-Digital/login.dfe.notifications.jobs/releases/tag/v6.3.1), in both `package.json` and `package-lock.json`.
- Updates the version of the login.dfe.jobs package to match the next available patch version, in both `package.json` and `package-lock.json`.