### PR TITLE
[DSI-7398] Update Support console UI to align with the emails received by the users

### DIFF
--- a/src/handlers/notifications/invite/newUserInvitationV2.js
+++ b/src/handlers/notifications/invite/newUserInvitationV2.js
@@ -49,8 +49,11 @@ const process = async (config, logger, data) => {
             code: data.code,
             reason,
             subject: data.overrides?.subject
-              ? data.overrides.subject
-              : "You’ve been invited to join DfE Sign-in",
+              ? data.overrides.subject.replace(
+                  "((VERIFICATION CODE))",
+                  data.code,
+                )
+              : `${data.code} is your DfE Sign-in verification code`,
           },
         });
       }

--- a/test/handlers/notifications/invitationTests/newUserInvitationV2.withoutEntra.test.js
+++ b/test/handlers/notifications/invitationTests/newUserInvitationV2.withoutEntra.test.js
@@ -88,14 +88,40 @@ describe("when sending v2 user invitation when Entra feature flag is turned off"
       it("assumes the default value when no override is provided", async () => {
         const handler = getHandler(config);
 
-        await handler.processor(commonJobData);
+        await handler.processor({
+          ...commonJobData,
+          code: "ABC123",
+        });
 
         expect(mockSendEmail).toHaveBeenCalledWith(
           expect.anything(),
           expect.anything(),
           expect.objectContaining({
             personalisation: expect.objectContaining({
-              subject: "You’ve been invited to join DfE Sign-in",
+              subject: "ABC123 is your DfE Sign-in verification code",
+            }),
+          }),
+        );
+      });
+
+      it("replaces the placeholder with the actual verification code", async () => {
+        const handler = getHandler(config);
+
+        await handler.processor({
+          ...commonJobData,
+          code: "ABC123",
+          overrides: {
+            subject:
+              "((VERIFICATION CODE)) is your DfE Sign-in verification code",
+          },
+        });
+
+        expect(mockSendEmail).toHaveBeenCalledWith(
+          expect.anything(),
+          expect.anything(),
+          expect.objectContaining({
+            personalisation: expect.objectContaining({
+              subject: "ABC123 is your DfE Sign-in verification code",
             }),
           }),
         );


### PR DESCRIPTION
## Summary
Jira ticket: [DSI-7398](https://dfe-secureaccess.atlassian.net/browse/DSI-7398)

## Changes

- Ensured verification code is send to `inviteNewUser` Gov notify
- Updated test to align with changes

## Related PRs: 

- https://github.com/DFE-Digital/login.dfe.support/pull/529