### PR TITLE
[DSI-7450] Add template mapping for Entra OTP verification code email template

### DIFF
--- a/src/infrastructure/config/schema.js
+++ b/src/infrastructure/config/schema.js
@@ -56,6 +56,9 @@ const govNotifyEmailTemplatesSchema = new SimpleSchema({
   inviteNewUserEntra: String,
   notifyExistingUserWhenAttemptingToRegisterAgain: String,
   selfRegisterNewAccount: String,
+
+  // Verification
+  entraOtpEmail: String,
 });
 
 const govNotifyTemplatesSchema = new SimpleSchema({


### PR DESCRIPTION
This PR introduces a template mapping for Entra OTP verification code email templates.

Even though this isn't used by the jobs component; this configuration is shared with `login.dfe.entra-auth-extensions` and as such must have a matching config schema.