### PR TITLE
[DSI-7545] Guard supportrequest_v1 handler against missing param

### DIFF
--- a/src/handlers/notifications/support/supportRequestV1.js
+++ b/src/handlers/notifications/support/supportRequestV1.js
@@ -14,7 +14,7 @@ const process = async (config, logger, data) => {
         email: data.email,
         orgName: data.orgName ?? "",
         urn: data.urn ?? "",
-        service: data.service,
+        service: data.service ?? "",
         type: data.type,
         message: data.message,
         showAdditionalInfoHeader,


### PR DESCRIPTION
### Summary
Jira ticket: https://dfe-secureaccess.atlassian.net/browse/DSI-7582

`organisationrequest_v1` handler can log a job for `supportrequest_v1` in the event that there are no approvers for an organisation.  However, it logs the job without specifying a mandatory field `service` which causes a 400 error when attempting to send the email.

### Changes
Coalesce the property `service` within the supportrequest_v1 handler in the event that its not provided.