### PR TITLE
[DSI-7757] Add a rate-limiter policy to `supportRequestV1 `

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,8 +13,9 @@
         "agentkeepalive": "^4.6.0",
         "body-parser": "^1.20.3",
         "bullmq": "^5.41.5",
-        "dotenv": "^16.4.7",
+        "dotenv": "^16.5.0",
         "express": "^4.21.2",
+        "i": "^0.3.7",
         "jsonwebtoken": "^9.0.2",
         "login.dfe.api-client": "^1.0.9",
         "login.dfe.api.auth": "^2.3.4",
@@ -36,16 +37,16 @@
         "xml2js": "^0.5.0"
       },
       "devDependencies": {
-        "@eslint/js": "^9.26.0",
-        "eslint": "^9.26.0",
+        "@eslint/js": "^9.28.0",
+        "eslint": "^9.28.0",
         "eslint-formatter-junit": "^8.40.0",
-        "eslint-plugin-jest": "^28.11.0",
+        "eslint-plugin-jest": "^28.13.3",
         "globals": "^15.14.0",
         "husky": "^9.1.7",
         "jest": "^29.7.0",
         "jest-cli": "^29.7.0",
         "jest-junit": "^16.0.0",
-        "lint-staged": "^15.4.3",
+        "lint-staged": "^15.5.2",
         "node-mocks-http": "^1.17.2",
         "prettier": "^3.5.3"
       }
@@ -1028,10 +1029,11 @@
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.13.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/core/-/core-0.13.0.tgz",
-      "integrity": "sha1-vwLyCYRtO/mW+egAnbYt8nObRYw=",
+      "version": "0.14.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/core/-/core-0.14.0.tgz",
+      "integrity": "sha1-MmKJOAlo6vfpbzZOHkz4863y0AM=",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -1098,12 +1100,16 @@
       "dev": true
     },
     "node_modules/@eslint/js": {
-      "version": "9.26.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.26.0.tgz",
-      "integrity": "sha1-HhMSa2ej2xURHS3MYfaaKs/3C9U=",
+      "version": "9.28.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/js/-/js-9.28.0.tgz",
+      "integrity": "sha1-eCLMwvjK58PNT5Ajd9Ug6a4D+EQ=",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -1116,12 +1122,13 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.8",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.2.8.tgz",
-      "integrity": "sha1-R0iNj4FxtdRhPoMzE/POcI41Jfg=",
+      "version": "0.3.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@eslint/plugin-kit/-/plugin-kit-0.3.1.tgz",
+      "integrity": "sha1-txsDey1NaDlt8EqMNaSUgeVZMGc=",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.13.0",
+        "@eslint/core": "^0.14.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -1644,316 +1651,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@microsoft/applicationinsights-web-snippet/-/applicationinsights-web-snippet-1.0.1.tgz",
       "integrity": "sha1-a7eIspAuSL9dRgw4xrt/7daG3dc="
     },
-    "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.11.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@modelcontextprotocol/sdk/-/sdk-1.11.2.tgz",
-      "integrity": "sha1-2BeEwUDRqcyTf2Gvnwcdi3i+/jA=",
-      "dev": true,
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "cors": "^2.8.5",
-        "cross-spawn": "^7.0.3",
-        "eventsource": "^3.0.2",
-        "express": "^5.0.1",
-        "express-rate-limit": "^7.5.0",
-        "pkce-challenge": "^5.0.0",
-        "raw-body": "^3.0.0",
-        "zod": "^3.23.8",
-        "zod-to-json-schema": "^3.24.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha1-u89LpQdUZ/PyEx6rPP/HPC9deJU=",
-      "dev": true,
-      "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha1-96llbeMFJJpxW1Sbe4/Rq5393Po=",
-      "dev": true,
-      "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha1-hEQmyzmPk0yu/LsXIgASa8fOrOI=",
-      "dev": true,
-      "dependencies": {
-        "safe-buffer": "5.2.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha1-V8f8PMKTrKuf7FTXPhVpDr5KF5M=",
-      "dev": true,
-      "engines": {
-        "node": ">=6.6.0"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express/-/express-5.1.0.tgz",
-      "integrity": "sha1-0xvq9xWgAW8NU/R9O016zyjHXMk=",
-      "dev": true,
-      "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
-      },
-      "engines": {
-        "node": ">= 18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha1-cjBjc6qJ0FqCQu1WnthqG/98Vh8=",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha1-jdffahs6Gzpc8YbAWl3SZ2ImNaQ=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha1-pS+AvzjaGVLrXGgXkHGYcaGnJQE=",
-      "dev": true,
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha1-ardLjy0zIPIGSyqHo455Mf86VWE=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha1-6pIvZgY1oiSe5WXgRJ+VHmtgOAg=",
-      "dev": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha1-zds+5PnGRTDf9kAjZmHULLajFPU=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha1-sdlNaZepsy/WnrrtDbc96Ky1Gc4=",
-      "dev": true,
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "dev": true
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha1-tskbtHFy1p+Tz9fDV7u1KQGbX2o=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha1-xj+kBoDSxclBQSoOiZyJr2DAqTA=",
-      "dev": true,
-      "dependencies": {
-        "side-channel": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha1-JbNHbwelFgBhna4/6C3cKKNuXg8=",
-      "dev": true,
-      "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/send/-/send-1.2.0.tgz",
-      "integrity": "sha1-MqdVT7d3uDHfqCg3D3c6OAjTchI=",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.3.5",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha1-nAJWTuJZvdIlG4LWWaLn4ZONZvk=",
-      "dev": true,
-      "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/@modelcontextprotocol/sdk/node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha1-ZPbPA/kvzkAVwrIkeT9r3UsGjJc=",
-      "dev": true,
-      "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
       "version": "3.0.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.3.tgz",
@@ -2180,6 +1877,7 @@
       "version": "2.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@pm2/agent/-/agent-2.0.4.tgz",
       "integrity": "sha1-pmmabFd0FJISl3brWnq8FeUGcss=",
+      "license": "AGPL-3.0",
       "dependencies": {
         "async": "~3.2.0",
         "chalk": "~3.0.0",
@@ -2200,6 +1898,7 @@
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -2211,12 +1910,14 @@
     "node_modules/@pm2/agent/node_modules/dayjs": {
       "version": "1.8.36",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dayjs/-/dayjs-1.8.36.tgz",
-      "integrity": "sha1-vjbiSEZ6+r+PWoa64N4M3O7M7VA="
+      "integrity": "sha1-vjbiSEZ6+r+PWoa64N4M3O7M7VA=",
+      "license": "MIT"
     },
     "node_modules/@pm2/agent/node_modules/debug": {
       "version": "4.3.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.7.tgz",
       "integrity": "sha1-h5RbQVGgEddtlaGY1xEchlw2ClI=",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2233,6 +1934,7 @@
       "version": "6.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2243,12 +1945,14 @@
     "node_modules/@pm2/agent/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
     "node_modules/@pm2/agent/node_modules/semver": {
       "version": "7.5.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.5.4.tgz",
       "integrity": "sha1-SDmG7E7TjhxsSMNIlKkYLb/2im4=",
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2262,12 +1966,14 @@
     "node_modules/@pm2/agent/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+      "license": "ISC"
     },
     "node_modules/@pm2/io": {
       "version": "6.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@pm2/io/-/io-6.0.1.tgz",
       "integrity": "sha1-MA/vpIUxfybjvDSNoGHKOVpSFJo=",
+      "license": "Apache-2",
       "dependencies": {
         "async": "~2.6.1",
         "debug": "~4.3.1",
@@ -2286,6 +1992,7 @@
       "version": "2.6.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/async/-/async-2.6.4.tgz",
       "integrity": "sha1-cGt/9ghGZM1+rnE/b5ZUM7VQQiE=",
+      "license": "MIT",
       "dependencies": {
         "lodash": "^4.17.14"
       }
@@ -2294,6 +2001,7 @@
       "version": "4.3.7",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.3.7.tgz",
       "integrity": "sha1-h5RbQVGgEddtlaGY1xEchlw2ClI=",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -2309,12 +2017,14 @@
     "node_modules/@pm2/io/node_modules/eventemitter2": {
       "version": "6.4.9",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eventemitter2/-/eventemitter2-6.4.9.tgz",
-      "integrity": "sha1-QfJ1B4G0Iw7ViCe8EZ0pNHHssSU="
+      "integrity": "sha1-QfJ1B4G0Iw7ViCe8EZ0pNHHssSU=",
+      "license": "MIT"
     },
     "node_modules/@pm2/io/node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha1-bW/mVw69lqr5D8rR2vo7JWbbOpQ=",
+      "license": "ISC",
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -2325,12 +2035,14 @@
     "node_modules/@pm2/io/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
     "node_modules/@pm2/io/node_modules/require-in-the-middle": {
       "version": "5.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/require-in-the-middle/-/require-in-the-middle-5.2.0.tgz",
       "integrity": "sha1-S3HjzH9Zl3EAr5vrdr8tBWpabeI=",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.1.1",
         "module-details-from-path": "^1.0.3",
@@ -2344,6 +2056,7 @@
       "version": "7.5.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/semver/-/semver-7.5.4.tgz",
       "integrity": "sha1-SDmG7E7TjhxsSMNIlKkYLb/2im4=",
+      "license": "ISC",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -2357,12 +2070,14 @@
     "node_modules/@pm2/io/node_modules/tslib": {
       "version": "1.9.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/tslib/-/tslib-1.9.3.tgz",
-      "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY="
+      "integrity": "sha1-1+TdeSRdhUKMTX5IIqeZF5VMooY=",
+      "license": "Apache-2.0"
     },
     "node_modules/@pm2/io/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI="
+      "integrity": "sha1-m7knkNnA7/7GO+c1GeEaNQGaOnI=",
+      "license": "ISC"
     },
     "node_modules/@pm2/js-api": {
       "version": "0.8.0",
@@ -2492,7 +2207,8 @@
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
-      "integrity": "sha1-207P1JmpdlqyQALDtpbQLm0yoSw="
+      "integrity": "sha1-207P1JmpdlqyQALDtpbQLm0yoSw=",
+      "license": "MIT"
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2586,7 +2302,8 @@
       "version": "7.0.15",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha1-WWoXRyM2lNUPatinhp/Lb1bPWEE=",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/ms": {
       "version": "2.1.0",
@@ -2883,12 +2600,14 @@
     "node_modules/amp": {
       "version": "0.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/amp/-/amp-0.3.1.tgz",
-      "integrity": "sha1-at+NWKdPNh6CwfqNOJwHnhOfxH0="
+      "integrity": "sha1-at+NWKdPNh6CwfqNOJwHnhOfxH0=",
+      "license": "MIT"
     },
     "node_modules/amp-message": {
       "version": "0.1.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/amp-message/-/amp-message-0.1.2.tgz",
       "integrity": "sha1-p48cmJlQh602GSpBKY5NtJ49/EU=",
+      "license": "MIT",
       "dependencies": {
         "amp": "0.3.1"
       }
@@ -3003,6 +2722,7 @@
       "version": "0.13.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ast-types/-/ast-types-0.13.4.tgz",
       "integrity": "sha1-7g13s0MmOWXsw/ti2hbnIisrZ4I=",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.1"
       },
@@ -3217,6 +2937,7 @@
       "version": "5.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/basic-ftp/-/basic-ftp-5.0.5.tgz",
       "integrity": "sha1-FKR09f/+zKH09AbxwmsY+AAiWsA=",
+      "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
       }
@@ -3931,19 +3652,6 @@
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/core-util-is/-/core-util-is-1.0.2.tgz",
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
-    "node_modules/cors": {
-      "version": "2.8.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/cors/-/cors-2.8.5.tgz",
-      "integrity": "sha1-6sEdpRWS3Ya58G9uesKTs9+HXSk=",
-      "dev": true,
-      "dependencies": {
-        "object-assign": "^4",
-        "vary": "^1"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
     "node_modules/create-jest": {
       "version": "29.7.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/create-jest/-/create-jest-29.7.0.tgz",
@@ -4004,6 +3712,7 @@
       "version": "6.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
       "integrity": "sha1-ili7ZzhLJho47xi+oYEMsBut0os=",
+      "license": "MIT",
       "engines": {
         "node": ">= 14"
       }
@@ -4091,6 +3800,7 @@
       "version": "5.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/degenerator/-/degenerator-5.0.1.tgz",
       "integrity": "sha1-lAO/KXxtrZoezkCbN9snlU+R8vU=",
+      "license": "MIT",
       "dependencies": {
         "ast-types": "^0.13.4",
         "escodegen": "^2.1.0",
@@ -4177,10 +3887,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.4.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dotenv/-/dotenv-16.4.7.tgz",
-      "integrity": "sha1-DiDFuClQFAqpm+NgqKX1IzX1PCY=",
-      "license": "BSD-2-Clause",
+      "version": "16.5.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/dotenv/-/dotenv-16.5.0.tgz",
+      "integrity": "sha1-CStJ8l+AjwIAUAUdH/JY5ATHhpI=",
       "engines": {
         "node": ">=12"
       },
@@ -4398,6 +4107,7 @@
       "version": "2.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha1-upO7t6Q5htKdYEH5n1Ji2nc+Lhc=",
+      "license": "BSD-2-Clause",
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -4415,23 +4125,23 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.26.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.26.0.tgz",
-      "integrity": "sha1-l4/gKa3CrO7SirQ3vKh26DRhw7Q=",
+      "version": "9.28.0",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint/-/eslint-9.28.0.tgz",
+      "integrity": "sha1-sLy+gqFpRaQJBpJL6nXotJgM7X0=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
         "@eslint/config-array": "^0.20.0",
         "@eslint/config-helpers": "^0.2.1",
-        "@eslint/core": "^0.13.0",
+        "@eslint/core": "^0.14.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.26.0",
-        "@eslint/plugin-kit": "^0.2.8",
+        "@eslint/js": "9.28.0",
+        "@eslint/plugin-kit": "^0.3.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
-        "@modelcontextprotocol/sdk": "^1.8.0",
         "@types/estree": "^1.0.6",
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
@@ -4455,8 +4165,7 @@
         "lodash.merge": "^4.6.2",
         "minimatch": "^3.1.2",
         "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "zod": "^3.24.2"
+        "optionator": "^0.9.3"
       },
       "bin": {
         "eslint": "bin/eslint.js"
@@ -4486,10 +4195,11 @@
       }
     },
     "node_modules/eslint-plugin-jest": {
-      "version": "28.11.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-jest/-/eslint-plugin-jest-28.11.0.tgz",
-      "integrity": "sha1-JkHstEEZQbvds9fPio/xFj+7UQ4=",
+      "version": "28.13.3",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eslint-plugin-jest/-/eslint-plugin-jest-28.13.3.tgz",
+      "integrity": "sha1-N3TQLXRvn7GiXkqMnLZowown9HY=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/utils": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
@@ -4649,7 +4359,8 @@
     "node_modules/eventemitter2": {
       "version": "5.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eventemitter2/-/eventemitter2-5.0.1.tgz",
-      "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI="
+      "integrity": "sha1-YZegldX7a1folC9v1+qtY6CclFI=",
+      "license": "MIT"
     },
     "node_modules/eventemitter3": {
       "version": "5.0.1",
@@ -4663,27 +4374,6 @@
       "integrity": "sha1-Mala0Kkk4tLEGagTrrLE6HjqdAA=",
       "engines": {
         "node": ">=0.8.x"
-      }
-    },
-    "node_modules/eventsource": {
-      "version": "3.0.7",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eventsource/-/eventsource-3.0.7.tgz",
-      "integrity": "sha1-EVdiLi9Td7tq7yEUNycougwVaYk=",
-      "dev": true,
-      "dependencies": {
-        "eventsource-parser": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/eventsource-parser": {
-      "version": "3.0.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eventsource-parser/-/eventsource-parser-3.0.1.tgz",
-      "integrity": "sha1-XjWNuppVumTKkNqIPEyjW9gkZ70=",
-      "dev": true,
-      "engines": {
-        "node": ">=18.0.0"
       }
     },
     "node_modules/execa": {
@@ -4779,21 +4469,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/express-rate-limit": {
-      "version": "7.5.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
-      "integrity": "sha1-ameZCnJLT7vGkRlBn+71DFHoso8=",
-      "dev": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/express-rate-limit"
-      },
-      "peerDependencies": {
-        "express": "^4.11 || 5 || ^5.0.0-beta.1"
-      }
-    },
     "node_modules/extrareqp2": {
       "version": "1.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/extrareqp2/-/extrareqp2-1.0.0.tgz",
@@ -4847,7 +4522,8 @@
     "node_modules/fast-json-patch": {
       "version": "3.1.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fast-json-patch/-/fast-json-patch-3.1.1.tgz",
-      "integrity": "sha1-hQZOobHr+Xo/etAeI/kzfnLGaUc="
+      "integrity": "sha1-hQZOobHr+Xo/etAeI/kzfnLGaUc=",
+      "license": "MIT"
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
@@ -4882,7 +4558,8 @@
     "node_modules/fclone": {
       "version": "1.0.11",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/fclone/-/fclone-1.0.11.tgz",
-      "integrity": "sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA="
+      "integrity": "sha1-EOhdo4v+p/xZk0HClu4ddyZu5kA=",
+      "license": "MIT"
     },
     "node_modules/fecha": {
       "version": "4.2.3",
@@ -5161,6 +4838,7 @@
       "version": "6.0.4",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/get-uri/-/get-uri-6.0.4.tgz",
       "integrity": "sha1-barunhL5dZ4Z5VujE5Vog+9Q4Kc=",
+      "license": "MIT",
       "dependencies": {
         "basic-ftp": "^5.0.2",
         "data-uri-to-buffer": "^6.0.2",
@@ -5171,9 +4849,10 @@
       }
     },
     "node_modules/get-uri/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
+      "version": "4.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5189,7 +4868,8 @@
     "node_modules/get-uri/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
     "node_modules/git-node-fs": {
       "version": "1.0.0",
@@ -5425,6 +5105,14 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/i": {
+      "version": "0.3.7",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/i/-/i-0.3.7.tgz",
+      "integrity": "sha1-KnQ3qSPVnBSxckPcY6VJryTYV5k=",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -5600,6 +5288,7 @@
       "version": "9.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ip-address/-/ip-address-9.0.5.tgz",
       "integrity": "sha1-EXqWCBmwh4DDvR8U7zwcwdPz6lo=",
+      "license": "MIT",
       "dependencies": {
         "jsbn": "1.1.0",
         "sprintf-js": "^1.1.3"
@@ -5611,7 +5300,8 @@
     "node_modules/ip-address/node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/sprintf-js/-/sprintf-js-1.1.3.tgz",
-      "integrity": "sha1-SRS5A6L4toXRf994pw6RfocuREo="
+      "integrity": "sha1-SRS5A6L4toXRf994pw6RfocuREo=",
+      "license": "BSD-3-Clause"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",
@@ -5730,12 +5420,6 @@
       "engines": {
         "node": ">=0.12.0"
       }
-    },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha1-Qv+fhCBsGZHSbev1IN1cAQQt0vM=",
-      "dev": true
     },
     "node_modules/is-stream": {
       "version": "2.0.1",
@@ -6485,7 +6169,8 @@
     "node_modules/jsbn": {
       "version": "1.1.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/jsbn/-/jsbn-1.1.0.tgz",
-      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA="
+      "integrity": "sha1-sBMHyym2GKHtJux56RH4A8TaAEA=",
+      "license": "MIT"
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -6613,6 +6298,7 @@
       "version": "1.0.11",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lazy/-/lazy-1.0.11.tgz",
       "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA=",
+      "license": "MIT",
       "engines": {
         "node": ">=0.2.0"
       }
@@ -6658,10 +6344,11 @@
       "dev": true
     },
     "node_modules/lint-staged": {
-      "version": "15.4.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lint-staged/-/lint-staged-15.4.3.tgz",
-      "integrity": "sha1-5zWHzIV/WAyZ+Qer7+msjY1edME=",
+      "version": "15.5.2",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lint-staged/-/lint-staged-15.5.2.tgz",
+      "integrity": "sha1-vv8Cj9BoH32yb/u2cFCiHtTQWaM=",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "chalk": "^5.4.1",
         "commander": "^13.1.0",
@@ -7563,6 +7250,7 @@
       "version": "2.0.2",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/netmask/-/netmask-2.0.2.tgz",
       "integrity": "sha1-iwGgdkQGXVNjg4NYI7xSAE66xec=",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
       }
@@ -7791,6 +7479,7 @@
       "version": "0.6.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/nssocket/-/nssocket-0.6.0.tgz",
       "integrity": "sha1-Wflvb/MhVm8zxw99vu7N/cBxVPo=",
+      "license": "MIT",
       "dependencies": {
         "eventemitter2": "~0.4.14",
         "lazy": "~1.0.11"
@@ -7802,21 +7491,13 @@
     "node_modules/nssocket/node_modules/eventemitter2": {
       "version": "0.4.14",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/eventemitter2/-/eventemitter2-0.4.14.tgz",
-      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas="
+      "integrity": "sha1-j2G3XN4BKy6esoTUVFWDtWQ7Yas=",
+      "license": "MIT"
     },
     "node_modules/oauth": {
       "version": "0.9.15",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/oauth/-/oauth-0.9.15.tgz",
       "integrity": "sha1-vR/vr2hslrdUda7VGWQS/2DPucE="
-    },
-    "node_modules/object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -7949,6 +7630,7 @@
       "version": "7.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz",
       "integrity": "sha1-nPrzP/Jdo29hR6IIRCMOySwG5d8=",
+      "license": "MIT",
       "dependencies": {
         "@tootallnate/quickjs-emscripten": "^0.23.0",
         "agent-base": "^7.1.2",
@@ -7964,9 +7646,10 @@
       }
     },
     "node_modules/pac-proxy-agent/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
+      "version": "4.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -7982,12 +7665,14 @@
     "node_modules/pac-proxy-agent/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
     "node_modules/pac-resolver": {
       "version": "7.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pac-resolver/-/pac-resolver-7.0.1.tgz",
       "integrity": "sha1-VGdVWOo2i2TSEP2ckqZAtfO4q7Y=",
+      "license": "MIT",
       "dependencies": {
         "degenerator": "^5.0.0",
         "netmask": "^2.0.2"
@@ -8301,15 +7986,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/pkce-challenge": {
-      "version": "5.0.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pkce-challenge/-/pkce-challenge-5.0.0.tgz",
-      "integrity": "sha1-w6QFy0nicglKOOiQorUdoCKMTZc=",
-      "dev": true,
-      "engines": {
-        "node": ">=16.20.0"
-      }
-    },
     "node_modules/pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -8378,6 +8054,7 @@
       "version": "5.4.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pm2/-/pm2-5.4.3.tgz",
       "integrity": "sha1-TYxFbHqi9d1ZcU/RMOnC8dkk6G4=",
+      "license": "AGPL-3.0",
       "dependencies": {
         "@pm2/agent": "~2.0.0",
         "@pm2/io": "~6.0.1",
@@ -8426,6 +8103,7 @@
       "version": "4.0.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pm2-axon/-/pm2-axon-4.0.1.tgz",
       "integrity": "sha1-p7S7WG6a6zWxBCtIjN4Vtgyrr9I=",
+      "license": "MIT",
       "dependencies": {
         "amp": "~0.3.1",
         "amp-message": "~0.1.1",
@@ -8440,6 +8118,7 @@
       "version": "0.7.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/pm2-axon-rpc/-/pm2-axon-rpc-0.7.1.tgz",
       "integrity": "sha1-La7FODpjE1s/GLq7cCZtrNy8Qpo=",
+      "license": "MIT",
       "dependencies": {
         "debug": "^4.3.1"
       },
@@ -8448,9 +8127,10 @@
       }
     },
     "node_modules/pm2-axon-rpc/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
+      "version": "4.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -8466,12 +8146,14 @@
     "node_modules/pm2-axon-rpc/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
     "node_modules/pm2-axon/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
+      "version": "4.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -8487,7 +8169,8 @@
     "node_modules/pm2-axon/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
     "node_modules/pm2-deploy": {
       "version": "1.0.2",
@@ -8561,6 +8244,7 @@
       "version": "3.0.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/chalk/-/chalk-3.0.0.tgz",
       "integrity": "sha1-P3PCv1JlkfV0zEksUeJFY0n4ROQ=",
+      "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
         "supports-color": "^7.1.0"
@@ -8734,6 +8418,7 @@
       "version": "6.3.1",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/proxy-agent/-/proxy-agent-6.3.1.tgz",
       "integrity": "sha1-QOeyMFUs9E/SP/r3xZAktpJhJoc=",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.0.2",
         "debug": "^4.3.4",
@@ -8749,9 +8434,10 @@
       }
     },
     "node_modules/proxy-agent/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
+      "version": "4.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -8768,6 +8454,7 @@
       "version": "7.18.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/lru-cache/-/lru-cache-7.18.3.tgz",
       "integrity": "sha1-95OJbg/Q6VSlnf3YLwdzgI32qok=",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -8775,7 +8462,8 @@
     "node_modules/proxy-agent/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -9129,54 +8817,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/router/-/router-2.2.0.tgz",
-      "integrity": "sha1-AZvmILcRyHZBFnzHm5kJDwCxRu8=",
-      "dev": true,
-      "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
-      },
-      "engines": {
-        "node": ">= 18"
-      }
-    },
-    "node_modules/router/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
-      "dev": true,
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/router/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
-      "dev": true
-    },
-    "node_modules/router/node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha1-c5kMwp5Xo/8qDZFAlRVt9dt56LQ=",
-      "dev": true,
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/run-applescript": {
@@ -9624,15 +9264,17 @@
       "version": "4.2.0",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha1-bh1x+k8YwF99D/IW3RakgdDo2a4=",
+      "license": "MIT",
       "engines": {
         "node": ">= 6.0.0",
         "npm": ">= 3.0.0"
       }
     },
     "node_modules/socks": {
-      "version": "2.8.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/socks/-/socks-2.8.4.tgz",
-      "integrity": "sha1-BxCXVc3U2gMmm9pHJbqgYatW1cw=",
+      "version": "2.8.5",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/socks/-/socks-2.8.5.tgz",
+      "integrity": "sha1-v+GPXq0e/JP17JDHn6i9zLzuLmQ=",
+      "license": "MIT",
       "dependencies": {
         "ip-address": "^9.0.5",
         "smart-buffer": "^4.2.0"
@@ -9646,6 +9288,7 @@
       "version": "8.0.5",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz",
       "integrity": "sha1-uc205+mYUJ12WdaJznaXrCFkW+4=",
+      "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
         "debug": "^4.3.4",
@@ -9656,9 +9299,10 @@
       }
     },
     "node_modules/socks-proxy-agent/node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha1-Kz8q6i/+t3ZHdGAmc3fchxD6uoo=",
+      "version": "4.4.1",
+      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha1-5ai8bLxMbNPmQwiwaTo9T6VQGJs=",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -9674,7 +9318,8 @@
     "node_modules/socks-proxy-agent/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI="
+      "integrity": "sha1-V0yBOM4dK1hh8LRFedut1gxmFbI=",
+      "license": "MIT"
     },
     "node_modules/source-map": {
       "version": "0.6.1",
@@ -10597,24 +10242,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zod": {
-      "version": "3.24.4",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/zod/-/zod-3.24.4.tgz",
-      "integrity": "sha1-4uLMpfqqAS125SfQ02Yi4KkMMV8=",
-      "dev": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/zod-to-json-schema": {
-      "version": "3.24.5",
-      "resolved": "https://dfe-ssp.pkgs.visualstudio.com/_packaging/Signin-Default/npm/registry/zod-to-json-schema/-/zod-to-json-schema-3.24.5.tgz",
-      "integrity": "sha1-0QlUQLFH+3wgk4EqU8VN+NXfUKM=",
-      "dev": true,
-      "peerDependencies": {
-        "zod": "^3.24.1"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,8 +31,9 @@
     "agentkeepalive": "^4.6.0",
     "body-parser": "^1.20.3",
     "bullmq": "^5.41.5",
-    "dotenv": "^16.4.7",
+    "dotenv": "^16.5.0",
     "express": "^4.21.2",
+    "i": "^0.3.7",
     "jsonwebtoken": "^9.0.2",
     "login.dfe.api-client": "^1.0.9",
     "login.dfe.api.auth": "^2.3.4",
@@ -54,16 +55,16 @@
     "xml2js": "^0.5.0"
   },
   "devDependencies": {
-    "@eslint/js": "^9.26.0",
-    "eslint": "^9.26.0",
+    "@eslint/js": "^9.28.0",
+    "eslint": "^9.28.0",
     "eslint-formatter-junit": "^8.40.0",
-    "eslint-plugin-jest": "^28.11.0",
+    "eslint-plugin-jest": "^28.13.3",
     "globals": "^15.14.0",
     "husky": "^9.1.7",
     "jest": "^29.7.0",
     "jest-cli": "^29.7.0",
     "jest-junit": "^16.0.0",
-    "lint-staged": "^15.4.3",
+    "lint-staged": "^15.5.2",
     "node-mocks-http": "^1.17.2",
     "prettier": "^3.5.3"
   }

--- a/src/handlers/notifications/support/supportRequestV1.js
+++ b/src/handlers/notifications/support/supportRequestV1.js
@@ -25,8 +25,16 @@ const process = async (config, logger, data) => {
   );
 };
 
+// DSI-7757 requires that supportrequest_v1 has a limiter policy so-as to
+// not trigger ServiceNow's 'flood detection filter threshold' which is
+// set at 50 emails per 5 minute timeframe.  The request is that we
+// send 10% fewer (45) messages within the specified timeframe (300000)
 const getHandler = (config, logger) => ({
   type: "supportrequest_v1",
+  limiter: {
+    max: 45,
+    duration: 300000,
+  },
   processor: async (data) => {
     await process(config, logger, data);
   },

--- a/src/infrastructure/jobQueue/MonitorBull.js
+++ b/src/infrastructure/jobQueue/MonitorBull.js
@@ -30,13 +30,26 @@ class MonitorBull {
   start() {
     // Closely matches Kue which "creates" a worker per "mapping.type"
     this.processorMapping.forEach((mapping) => {
-      logger.debug(`MonitorBull: start monitoring ${mapping.type}`);
+      let limiterPolicyDescription = "";
+      if (
+        mapping?.limiter &&
+        typeof mapping.limiter.max === "number" &&
+        typeof mapping.limiter.duration === "number"
+      ) {
+        limiterPolicyDescription = ` (with policy max: ${mapping.limiter.max} duration: ${mapping.limiter.duration})`;
+      }
+      logger.debug(
+        `MonitorBull: start monitoring ${mapping.type}${limiterPolicyDescription}`,
+      );
       const worker = new Worker(
         mapping.type,
         async (job) => {
           process(job, mapping.processor);
         },
-        { connection: { url: bullConnectionUrl } },
+        {
+          connection: { url: bullConnectionUrl },
+          limiter: mapping?.limiter,
+        },
       );
       this.workers.push(worker);
     });

--- a/test/handlers/notifications/supportTests/supportRequestV1.test.js
+++ b/test/handlers/notifications/supportTests/supportRequestV1.test.js
@@ -76,6 +76,14 @@ describe("When handling supportrequest_v1 job", () => {
     );
   });
 
+  it("should specify a limiter policy", async () => {
+    const handler = getHandler(config);
+    expect(handler.limiter).toMatchObject({
+      max: 45,
+      duration: 300000,
+    });
+  });
+
   it.each([
     ["", "", false],
     [null, "", false],

--- a/test/infrastructure/jobQueue/monitorBull.test.js
+++ b/test/infrastructure/jobQueue/monitorBull.test.js
@@ -29,6 +29,17 @@ describe("MonitorBull", () => {
         return Promise.resolve();
       },
     },
+    {
+      type: "test2",
+      limiter: {
+        max: 45,
+        duration: 300000,
+      },
+      processor: (jobData) => {
+        logger.info(`Test2 job - ${JSON.stringify(jobData)}`);
+        return Promise.resolve();
+      },
+    },
   ];
 
   it("should construct a new MonitorBull", async () => {
@@ -45,6 +56,9 @@ describe("MonitorBull", () => {
     });
     expect(logger.debug).toHaveBeenCalledWith(
       "MonitorBull: start monitoring test",
+    );
+    expect(logger.debug).toHaveBeenCalledWith(
+      "MonitorBull: start monitoring test2 (with policy max: 45 duration: 300000)",
     );
   });
 


### PR DESCRIPTION
### Summary
Jira ticket https://dfe-secureaccess.atlassian.net/browse/DSI-7757

### Changes
A `job handler` can now define a `limiter policy`, which will be applied to the BullMQ `Worker` during initialisation.

- Added a limiter policy against `src/handlers/notifications/support/supportRequestV1.js`
- During the `start()` method of `src/infrastructure/jobQueue/MonitorBull.js` look to see whether a handler has a limiter policy, and if so use it
- If a handler has a limiter policy then output the details to the console
- Update tests
- Update some external 3rd party packages