### PR TITLE
NSA-9613-Updated the removal notifications after sending the email for both service and organisation removals

### DIFF
--- a/src/handlers/notifications/serviceRemoved/userServiceRemovedV1.js
+++ b/src/handlers/notifications/serviceRemoved/userServiceRemovedV1.js
@@ -1,4 +1,6 @@
 const { getNotifyAdapter } = require("../../../infrastructure/notify");
+const { bullEnqueue } = require("../../../infrastructure/jobQueue/BullHelpers");
+const { getUserRaw } = require("login.dfe.api-client/users");
 
 const process = async (config, logger, data) => {
   const notify = getNotifyAdapter(config);
@@ -13,6 +15,24 @@ const process = async (config, logger, data) => {
       helpUrl: `${config.notifications.helpUrl}/contact-us`,
     },
   });
+
+  try {
+    const user = await getUserRaw({ by: { email: data.email } });
+    if (user?.sub) {
+      await bullEnqueue("userupdated_v1", { sub: user.sub });
+    } else {
+      logger?.warn(
+        "Could not resolve user by email for update notification",
+        {
+          email: data.email,
+        },
+      );
+    }
+  } catch (e) {
+    logger?.error("Failed to enqueue userupdated_v1 after service removal", {
+      error: { message: e.message, stack: e.stack },
+    });
+  }
 };
 
 const getHandler = (config, logger) => ({

--- a/src/handlers/notifications/userOrganisation/removedUserFromOrgV1.js
+++ b/src/handlers/notifications/userOrganisation/removedUserFromOrgV1.js
@@ -1,4 +1,6 @@
 const { getNotifyAdapter } = require("../../../infrastructure/notify");
+const { bullEnqueue } = require("../../../infrastructure/jobQueue/BullHelpers");
+const { getUserRaw } = require("login.dfe.api-client/users");
 
 const process = async (config, logger, data) => {
   const notify = getNotifyAdapter(config);
@@ -12,7 +14,25 @@ const process = async (config, logger, data) => {
       helpUrl: `${config.notifications.helpUrl}/contact-us`,
     },
   });
-};
+
+  try {
+    const user = await getUserRaw({ by: { email: data.email } });
+    if (user && user.sub) {
+      await bullEnqueue("userupdated_v1", { sub: user.sub });
+    } else {
+      logger?.warn(
+        "Could not resolve user by email for update notification",
+        {
+          email: data.email
+        },
+      );
+    }
+  } catch (e) {
+      logger?.error("Failed to enqueue userupdated_v1 after org removal", {
+        error: { message: e.message, stack: e.stack },
+      });
+    }
+  };
 
 const getHandler = (config, logger) => ({
   type: "userremovedfromorganisationrequest_v1",

--- a/src/infrastructure/config/index.js
+++ b/src/infrastructure/config/index.js
@@ -3,6 +3,16 @@ const os = require('os');
 const path = require('path');
 
 require('dotenv').config();
+const parseJson = (value, fallback) => {
+  try {
+    if (value === undefined || value === null || value === '') {
+      return fallback;
+    }
+    return JSON.parse(value);
+  } catch {
+    return fallback;
+  }
+};
 
 const config = {
   loggerSettings: {
@@ -74,7 +84,7 @@ const config = {
     envName: process.env.ENVIRONMENT_NAME,
     govNotify: {
         apiKey: process.env.GOVNOTIFY_API_KEY,
-        templates: JSON.parse(process.env.GOVNOTIFY_TEMP_MAP)
+        templates: parseJson(process.env.GOVNOTIFY_TEMP_MAP, {})
     },
     organisations: {
       type: "api",

--- a/test/handlers/notifications/serviceRemoved/userServiceRemovedV1.test.js
+++ b/test/handlers/notifications/serviceRemoved/userServiceRemovedV1.test.js
@@ -1,5 +1,12 @@
 jest.mock("../../../../src/infrastructure/notify");
+jest.mock("../../../../src/infrastructure/jobQueue/BullHelpers");
+jest.mock("login.dfe.api-client/users");
+
 const { getNotifyAdapter } = require("../../../../src/infrastructure/notify");
+const {
+  bullEnqueue,
+} = require("../../../../src/infrastructure/jobQueue/BullHelpers");
+const { getUserRaw } = require("login.dfe.api-client/users");
 const {
   getHandler,
 } = require("../../../../src/handlers/notifications/serviceRemoved/userServiceRemovedV1");
@@ -7,7 +14,7 @@ const {
 const config = {
   notifications: {
     helpUrl: "https://help.dfe.signin",
-    signInUrl: "https://signInUrl.test",
+    servicesUrl: "https://services.dfe.signin",
   },
 };
 
@@ -21,12 +28,24 @@ const jobData = {
 
 describe("When handling user service removed v1 job", () => {
   const mockSendEmail = jest.fn();
+  const mockBullEnqueue = jest.fn();
+  const mockGetUserRaw = jest.fn();
+  const mockLogger = {
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
 
   beforeEach(() => {
     mockSendEmail.mockReset();
+    mockBullEnqueue.mockReset();
+    mockGetUserRaw.mockReset();
+    mockLogger.warn.mockReset();
+    mockLogger.error.mockReset();
 
     getNotifyAdapter.mockReset();
     getNotifyAdapter.mockReturnValue({ sendEmail: mockSendEmail });
+    bullEnqueue.mockImplementation(mockBullEnqueue);
+    getUserRaw.mockImplementation(mockGetUserRaw);
   });
 
   it("should return a handler with a processor", async () => {
@@ -39,16 +58,17 @@ describe("When handling user service removed v1 job", () => {
   });
 
   it("should get email adapter with supplied config", async () => {
-    const handler = getHandler(config);
+    const handler = getHandler(config, mockLogger);
 
     await handler.processor(jobData);
 
     expect(getNotifyAdapter).toHaveBeenCalledTimes(1);
     expect(getNotifyAdapter).toHaveBeenCalledWith(config);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
   });
 
-  it("should send email with expected template", async () => {
-    const handler = getHandler(config);
+  it("should send email with userServiceRemoved template", async () => {
+    const handler = getHandler(config, mockLogger);
 
     await handler.processor(jobData);
 
@@ -61,7 +81,7 @@ describe("When handling user service removed v1 job", () => {
   });
 
   it("should send email to users email address", async () => {
-    const handler = getHandler(config);
+    const handler = getHandler(config, mockLogger);
 
     await handler.processor(jobData);
 
@@ -69,19 +89,6 @@ describe("When handling user service removed v1 job", () => {
     expect(mockSendEmail).toHaveBeenCalledWith(
       expect.anything(),
       jobData.email,
-      expect.anything(),
-    );
-  });
-
-  it("should send email with expected personalisation data when the request is approved", async () => {
-    const handler = getHandler(config);
-
-    await handler.processor(jobData);
-
-    expect(mockSendEmail).toHaveBeenCalledTimes(1);
-    expect(mockSendEmail).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
       expect.objectContaining({
         personalisation: expect.objectContaining({
           firstName: jobData.firstName,
@@ -93,5 +100,123 @@ describe("When handling user service removed v1 job", () => {
         }),
       }),
     );
+  });
+
+  describe("User update notification", () => {
+    it("should fetch user by email to get sub", async () => {
+      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockGetUserRaw).toHaveBeenCalledTimes(1);
+      expect(mockGetUserRaw).toHaveBeenCalledWith({
+        by: { email: jobData.email },
+      });
+    });
+
+    it("should enqueue userupdated_v1 job when user with sub is found", async () => {
+      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockBullEnqueue).toHaveBeenCalledTimes(1);
+      expect(mockBullEnqueue).toHaveBeenCalledWith("userupdated_v1", {
+        sub: "user-sub-123",
+      });
+    });
+
+    it("should not enqueue job when user does not have sub property", async () => {
+      mockGetUserRaw.mockResolvedValue({ name: "John Doe" });
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockBullEnqueue).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Could not resolve user by email for update notification",
+        { email: jobData.email },
+      );
+    });
+
+    it("should log warning when user is not found", async () => {
+      mockGetUserRaw.mockResolvedValue(null);
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockBullEnqueue).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Could not resolve user by email for update notification",
+        { email: jobData.email },
+      );
+    });
+
+    it("should not enqueue job when user is undefined", async () => {
+      mockGetUserRaw.mockResolvedValue(undefined);
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockBullEnqueue).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should log error when getUserRaw throws", async () => {
+      const error = new Error("API connection failed");
+      mockGetUserRaw.mockRejectedValue(error);
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to enqueue userupdated_v1 after service removal",
+        {
+          error: { message: error.message, stack: error.stack },
+        },
+      );
+    });
+
+    it("should log error when bullEnqueue throws", async () => {
+      const error = new Error("Queue connection failed");
+      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
+      mockBullEnqueue.mockRejectedValue(error);
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to enqueue userupdated_v1 after service removal",
+        {
+          error: { message: error.message, stack: error.stack },
+        },
+      );
+    });
+
+    it("should still send email even if user lookup fails", async () => {
+      mockGetUserRaw.mockRejectedValue(new Error("API error"));
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it("should continue without logger if logger is not provided", async () => {
+      mockGetUserRaw.mockResolvedValue(null);
+      const handler = getHandler(config);
+
+      // Should not throw
+      await handler.processor(jobData);
+
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/test/handlers/notifications/userOrganisation/removedUserFromOrgV1.test.js
+++ b/test/handlers/notifications/userOrganisation/removedUserFromOrgV1.test.js
@@ -1,5 +1,12 @@
 jest.mock("../../../../src/infrastructure/notify");
+jest.mock("../../../../src/infrastructure/jobQueue/BullHelpers");
+jest.mock("login.dfe.api-client/users");
+
 const { getNotifyAdapter } = require("../../../../src/infrastructure/notify");
+const {
+  bullEnqueue,
+} = require("../../../../src/infrastructure/jobQueue/BullHelpers");
+const { getUserRaw } = require("login.dfe.api-client/users");
 const {
   getHandler,
 } = require("../../../../src/handlers/notifications/userOrganisation/removedUserFromOrgV1");
@@ -7,7 +14,7 @@ const {
 const config = {
   notifications: {
     helpUrl: "https://help.dfe.signin",
-    signInUrl: "https://signInUrl.test",
+    servicesUrl: "https://services.dfe.signin",
   },
 };
 
@@ -20,12 +27,24 @@ const jobData = {
 
 describe("When handling user removed user from organisation v1 job", () => {
   const mockSendEmail = jest.fn();
+  const mockBullEnqueue = jest.fn();
+  const mockGetUserRaw = jest.fn();
+  const mockLogger = {
+    warn: jest.fn(),
+    error: jest.fn(),
+  };
 
   beforeEach(() => {
     mockSendEmail.mockReset();
+    mockBullEnqueue.mockReset();
+    mockGetUserRaw.mockReset();
+    mockLogger.warn.mockReset();
+    mockLogger.error.mockReset();
 
     getNotifyAdapter.mockReset();
     getNotifyAdapter.mockReturnValue({ sendEmail: mockSendEmail });
+    bullEnqueue.mockImplementation(mockBullEnqueue);
+    getUserRaw.mockImplementation(mockGetUserRaw);
   });
 
   it("should return a handler with a processor", async () => {
@@ -38,16 +57,17 @@ describe("When handling user removed user from organisation v1 job", () => {
   });
 
   it("should get email adapter with supplied config", async () => {
-    const handler = getHandler(config);
+    const handler = getHandler(config, mockLogger);
 
     await handler.processor(jobData);
 
     expect(getNotifyAdapter).toHaveBeenCalledTimes(1);
     expect(getNotifyAdapter).toHaveBeenCalledWith(config);
+    expect(mockSendEmail).toHaveBeenCalledTimes(1);
   });
 
-  it("should send email with expected template", async () => {
-    const handler = getHandler(config);
+  it("should send email with userRemovedFromOrganisation template", async () => {
+    const handler = getHandler(config, mockLogger);
 
     await handler.processor(jobData);
 
@@ -60,7 +80,7 @@ describe("When handling user removed user from organisation v1 job", () => {
   });
 
   it("should send email to users email address", async () => {
-    const handler = getHandler(config);
+    const handler = getHandler(config, mockLogger);
 
     await handler.processor(jobData);
 
@@ -68,19 +88,6 @@ describe("When handling user removed user from organisation v1 job", () => {
     expect(mockSendEmail).toHaveBeenCalledWith(
       expect.anything(),
       jobData.email,
-      expect.anything(),
-    );
-  });
-
-  it("should send email with expected personalisation data when the request is approved", async () => {
-    const handler = getHandler(config);
-
-    await handler.processor(jobData);
-
-    expect(mockSendEmail).toHaveBeenCalledTimes(1);
-    expect(mockSendEmail).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.anything(),
       expect.objectContaining({
         personalisation: expect.objectContaining({
           firstName: jobData.firstName,
@@ -91,5 +98,123 @@ describe("When handling user removed user from organisation v1 job", () => {
         }),
       }),
     );
+  });
+
+  describe("User update notification", () => {
+    it("should fetch user by email to get sub", async () => {
+      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockGetUserRaw).toHaveBeenCalledTimes(1);
+      expect(mockGetUserRaw).toHaveBeenCalledWith({
+        by: { email: jobData.email },
+      });
+    });
+
+    it("should enqueue userupdated_v1 job when user with sub is found", async () => {
+      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockBullEnqueue).toHaveBeenCalledTimes(1);
+      expect(mockBullEnqueue).toHaveBeenCalledWith("userupdated_v1", {
+        sub: "user-sub-123",
+      });
+    });
+
+    it("should not enqueue job when user does not have sub property", async () => {
+      mockGetUserRaw.mockResolvedValue({ name: "John Doe" });
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockBullEnqueue).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Could not resolve user by email for update notification",
+        { email: jobData.email },
+      );
+    });
+
+    it("should log warning when user is not found", async () => {
+      mockGetUserRaw.mockResolvedValue(null);
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockBullEnqueue).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        "Could not resolve user by email for update notification",
+        { email: jobData.email },
+      );
+    });
+
+    it("should not enqueue job when user is undefined", async () => {
+      mockGetUserRaw.mockResolvedValue(undefined);
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockBullEnqueue).not.toHaveBeenCalled();
+      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("Error handling", () => {
+    it("should log error when getUserRaw throws", async () => {
+      const error = new Error("API connection failed");
+      mockGetUserRaw.mockRejectedValue(error);
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to enqueue userupdated_v1 after org removal",
+        {
+          error: { message: error.message, stack: error.stack },
+        },
+      );
+    });
+
+    it("should log error when bullEnqueue throws", async () => {
+      const error = new Error("Queue connection failed");
+      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
+      mockBullEnqueue.mockRejectedValue(error);
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockLogger.error).toHaveBeenCalledTimes(1);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "Failed to enqueue userupdated_v1 after org removal",
+        {
+          error: { message: error.message, stack: error.stack },
+        },
+      );
+    });
+
+    it("should still send email even if user lookup fails", async () => {
+      mockGetUserRaw.mockRejectedValue(new Error("API error"));
+      const handler = getHandler(config, mockLogger);
+
+      await handler.processor(jobData);
+
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    });
+
+    it("should continue without logger if logger is not provided", async () => {
+      mockGetUserRaw.mockResolvedValue(null);
+      const handler = getHandler(config);
+
+      // Should not throw
+      await handler.processor(jobData);
+
+      expect(mockSendEmail).toHaveBeenCalledTimes(1);
+    });
   });
 });


### PR DESCRIPTION
we updated the removal notifications to also enqueue userupdated_v1 after sending the email for both service and organisation removals. This ensures downstream systems receive the user’s updated access state and the existing WS fan-out pipeline propagates the change