### PR TITLE
[NSA-9314] Fix deactivation sync for COLLECT/S2S on service removal

### DIFF
--- a/src/handlers/notifications/serviceRemoved/userServiceRemovedV1.js
+++ b/src/handlers/notifications/serviceRemoved/userServiceRemovedV1.js
@@ -1,6 +1,4 @@
 const { getNotifyAdapter } = require("../../../infrastructure/notify");
-const { bullEnqueue } = require("../../../infrastructure/jobQueue/BullHelpers");
-const { getUserRaw } = require("login.dfe.api-client/users");
 
 const process = async (config, logger, data) => {
   const notify = getNotifyAdapter(config);
@@ -15,24 +13,6 @@ const process = async (config, logger, data) => {
       helpUrl: `${config.notifications.helpUrl}/contact-us`,
     },
   });
-
-  try {
-    const user = await getUserRaw({ by: { email: data.email } });
-    if (user?.sub) {
-      await bullEnqueue("userupdated_v1", { sub: user.sub });
-    } else {
-      logger?.warn(
-        "Could not resolve user by email for update notification",
-        {
-          email: data.email,
-        },
-      );
-    }
-  } catch (e) {
-    logger?.error("Failed to enqueue userupdated_v1 after service removal", {
-      error: { message: e.message, stack: e.stack },
-    });
-  }
 };
 
 const getHandler = (config, logger) => ({

--- a/src/handlers/notifications/userOrganisation/removedUserFromOrgV1.js
+++ b/src/handlers/notifications/userOrganisation/removedUserFromOrgV1.js
@@ -1,6 +1,4 @@
 const { getNotifyAdapter } = require("../../../infrastructure/notify");
-const { bullEnqueue } = require("../../../infrastructure/jobQueue/BullHelpers");
-const { getUserRaw } = require("login.dfe.api-client/users");
 
 const process = async (config, logger, data) => {
   const notify = getNotifyAdapter(config);
@@ -14,25 +12,7 @@ const process = async (config, logger, data) => {
       helpUrl: `${config.notifications.helpUrl}/contact-us`,
     },
   });
-
-  try {
-    const user = await getUserRaw({ by: { email: data.email } });
-    if (user && user.sub) {
-      await bullEnqueue("userupdated_v1", { sub: user.sub });
-    } else {
-      logger?.warn(
-        "Could not resolve user by email for update notification",
-        {
-          email: data.email
-        },
-      );
-    }
-  } catch (e) {
-      logger?.error("Failed to enqueue userupdated_v1 after org removal", {
-        error: { message: e.message, stack: e.stack },
-      });
-    }
-  };
+};
 
 const getHandler = (config, logger) => ({
   type: "userremovedfromorganisationrequest_v1",

--- a/src/handlers/serviceNotifications/users/userUpdatedHandlerV1.js
+++ b/src/handlers/serviceNotifications/users/userUpdatedHandlerV1.js
@@ -114,6 +114,43 @@ const getRequiredJobs = async (config, logger, userData, correlationId) => {
 const process = async (config, logger, data, jobId) => {
   const correlationId = `userupdated-${jobId || uuid()}`;
 
+  if (data.removedServiceId) {
+    const applications = await getAllApplicationRequiringNotification(
+      config,
+      applictionRequiringNotificationCondition,
+      correlationId,
+      true,
+    );
+    const application = applications.find(
+      (a) => a.id.toLowerCase() === data.removedServiceId.toLowerCase(),
+    );
+    if (application) {
+      const user = await getUserRaw({ by: { id: data.sub } });
+      await bullEnqueue(`sendwsuserupdated_v1_${application.id}`, {
+        user: {
+          userId: user.sub,
+          firstName: user.given_name,
+          lastName: user.family_name,
+          email: user.email,
+          status: 0,
+          organisationId: data.removedOrgId,
+          roles: [],
+        },
+        applicationId: application.id,
+      });
+      logger.info(
+        `Deactivation sync enqueued for service ${data.removedServiceId} and user ${data.sub}`,
+        { correlationId },
+      );
+    } else {
+      logger.warn(
+        `Deactivation sync skipped: removedServiceId ${data.removedServiceId} did not match any legacy application`,
+        { correlationId, sub: data.sub },
+      );
+    }
+    return;
+  }
+
   const jobs = await getRequiredJobs(config, logger, data, correlationId);
 
   for (let i = 0; i < jobs.length; i += 1) {

--- a/test/handlers/notifications/serviceRemoved/userServiceRemovedV1.test.js
+++ b/test/handlers/notifications/serviceRemoved/userServiceRemovedV1.test.js
@@ -1,12 +1,6 @@
 jest.mock("../../../../src/infrastructure/notify");
-jest.mock("../../../../src/infrastructure/jobQueue/BullHelpers");
-jest.mock("login.dfe.api-client/users");
 
 const { getNotifyAdapter } = require("../../../../src/infrastructure/notify");
-const {
-  bullEnqueue,
-} = require("../../../../src/infrastructure/jobQueue/BullHelpers");
-const { getUserRaw } = require("login.dfe.api-client/users");
 const {
   getHandler,
 } = require("../../../../src/handlers/notifications/serviceRemoved/userServiceRemovedV1");
@@ -28,8 +22,6 @@ const jobData = {
 
 describe("When handling user service removed v1 job", () => {
   const mockSendEmail = jest.fn();
-  const mockBullEnqueue = jest.fn();
-  const mockGetUserRaw = jest.fn();
   const mockLogger = {
     warn: jest.fn(),
     error: jest.fn(),
@@ -37,15 +29,9 @@ describe("When handling user service removed v1 job", () => {
 
   beforeEach(() => {
     mockSendEmail.mockReset();
-    mockBullEnqueue.mockReset();
-    mockGetUserRaw.mockReset();
-    mockLogger.warn.mockReset();
-    mockLogger.error.mockReset();
 
     getNotifyAdapter.mockReset();
     getNotifyAdapter.mockReturnValue({ sendEmail: mockSendEmail });
-    bullEnqueue.mockImplementation(mockBullEnqueue);
-    getUserRaw.mockImplementation(mockGetUserRaw);
   });
 
   it("should return a handler with a processor", async () => {
@@ -100,123 +86,5 @@ describe("When handling user service removed v1 job", () => {
         }),
       }),
     );
-  });
-
-  describe("User update notification", () => {
-    it("should fetch user by email to get sub", async () => {
-      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockGetUserRaw).toHaveBeenCalledTimes(1);
-      expect(mockGetUserRaw).toHaveBeenCalledWith({
-        by: { email: jobData.email },
-      });
-    });
-
-    it("should enqueue userupdated_v1 job when user with sub is found", async () => {
-      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockBullEnqueue).toHaveBeenCalledTimes(1);
-      expect(mockBullEnqueue).toHaveBeenCalledWith("userupdated_v1", {
-        sub: "user-sub-123",
-      });
-    });
-
-    it("should not enqueue job when user does not have sub property", async () => {
-      mockGetUserRaw.mockResolvedValue({ name: "John Doe" });
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockBullEnqueue).not.toHaveBeenCalled();
-      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        "Could not resolve user by email for update notification",
-        { email: jobData.email },
-      );
-    });
-
-    it("should log warning when user is not found", async () => {
-      mockGetUserRaw.mockResolvedValue(null);
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockBullEnqueue).not.toHaveBeenCalled();
-      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        "Could not resolve user by email for update notification",
-        { email: jobData.email },
-      );
-    });
-
-    it("should not enqueue job when user is undefined", async () => {
-      mockGetUserRaw.mockResolvedValue(undefined);
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockBullEnqueue).not.toHaveBeenCalled();
-      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("Error handling", () => {
-    it("should log error when getUserRaw throws", async () => {
-      const error = new Error("API connection failed");
-      mockGetUserRaw.mockRejectedValue(error);
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockLogger.error).toHaveBeenCalledTimes(1);
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        "Failed to enqueue userupdated_v1 after service removal",
-        {
-          error: { message: error.message, stack: error.stack },
-        },
-      );
-    });
-
-    it("should log error when bullEnqueue throws", async () => {
-      const error = new Error("Queue connection failed");
-      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
-      mockBullEnqueue.mockRejectedValue(error);
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockLogger.error).toHaveBeenCalledTimes(1);
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        "Failed to enqueue userupdated_v1 after service removal",
-        {
-          error: { message: error.message, stack: error.stack },
-        },
-      );
-    });
-
-    it("should still send email even if user lookup fails", async () => {
-      mockGetUserRaw.mockRejectedValue(new Error("API error"));
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-    });
-
-    it("should continue without logger if logger is not provided", async () => {
-      mockGetUserRaw.mockResolvedValue(null);
-      const handler = getHandler(config);
-
-      // Should not throw
-      await handler.processor(jobData);
-
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/test/handlers/notifications/userOrganisation/removedUserFromOrgV1.test.js
+++ b/test/handlers/notifications/userOrganisation/removedUserFromOrgV1.test.js
@@ -1,12 +1,6 @@
 jest.mock("../../../../src/infrastructure/notify");
-jest.mock("../../../../src/infrastructure/jobQueue/BullHelpers");
-jest.mock("login.dfe.api-client/users");
 
 const { getNotifyAdapter } = require("../../../../src/infrastructure/notify");
-const {
-  bullEnqueue,
-} = require("../../../../src/infrastructure/jobQueue/BullHelpers");
-const { getUserRaw } = require("login.dfe.api-client/users");
 const {
   getHandler,
 } = require("../../../../src/handlers/notifications/userOrganisation/removedUserFromOrgV1");
@@ -27,8 +21,6 @@ const jobData = {
 
 describe("When handling user removed user from organisation v1 job", () => {
   const mockSendEmail = jest.fn();
-  const mockBullEnqueue = jest.fn();
-  const mockGetUserRaw = jest.fn();
   const mockLogger = {
     warn: jest.fn(),
     error: jest.fn(),
@@ -36,15 +28,9 @@ describe("When handling user removed user from organisation v1 job", () => {
 
   beforeEach(() => {
     mockSendEmail.mockReset();
-    mockBullEnqueue.mockReset();
-    mockGetUserRaw.mockReset();
-    mockLogger.warn.mockReset();
-    mockLogger.error.mockReset();
 
     getNotifyAdapter.mockReset();
     getNotifyAdapter.mockReturnValue({ sendEmail: mockSendEmail });
-    bullEnqueue.mockImplementation(mockBullEnqueue);
-    getUserRaw.mockImplementation(mockGetUserRaw);
   });
 
   it("should return a handler with a processor", async () => {
@@ -98,123 +84,5 @@ describe("When handling user removed user from organisation v1 job", () => {
         }),
       }),
     );
-  });
-
-  describe("User update notification", () => {
-    it("should fetch user by email to get sub", async () => {
-      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockGetUserRaw).toHaveBeenCalledTimes(1);
-      expect(mockGetUserRaw).toHaveBeenCalledWith({
-        by: { email: jobData.email },
-      });
-    });
-
-    it("should enqueue userupdated_v1 job when user with sub is found", async () => {
-      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockBullEnqueue).toHaveBeenCalledTimes(1);
-      expect(mockBullEnqueue).toHaveBeenCalledWith("userupdated_v1", {
-        sub: "user-sub-123",
-      });
-    });
-
-    it("should not enqueue job when user does not have sub property", async () => {
-      mockGetUserRaw.mockResolvedValue({ name: "John Doe" });
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockBullEnqueue).not.toHaveBeenCalled();
-      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        "Could not resolve user by email for update notification",
-        { email: jobData.email },
-      );
-    });
-
-    it("should log warning when user is not found", async () => {
-      mockGetUserRaw.mockResolvedValue(null);
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockBullEnqueue).not.toHaveBeenCalled();
-      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-      expect(mockLogger.warn).toHaveBeenCalledWith(
-        "Could not resolve user by email for update notification",
-        { email: jobData.email },
-      );
-    });
-
-    it("should not enqueue job when user is undefined", async () => {
-      mockGetUserRaw.mockResolvedValue(undefined);
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockBullEnqueue).not.toHaveBeenCalled();
-      expect(mockLogger.warn).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("Error handling", () => {
-    it("should log error when getUserRaw throws", async () => {
-      const error = new Error("API connection failed");
-      mockGetUserRaw.mockRejectedValue(error);
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockLogger.error).toHaveBeenCalledTimes(1);
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        "Failed to enqueue userupdated_v1 after org removal",
-        {
-          error: { message: error.message, stack: error.stack },
-        },
-      );
-    });
-
-    it("should log error when bullEnqueue throws", async () => {
-      const error = new Error("Queue connection failed");
-      mockGetUserRaw.mockResolvedValue({ sub: "user-sub-123" });
-      mockBullEnqueue.mockRejectedValue(error);
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockLogger.error).toHaveBeenCalledTimes(1);
-      expect(mockLogger.error).toHaveBeenCalledWith(
-        "Failed to enqueue userupdated_v1 after org removal",
-        {
-          error: { message: error.message, stack: error.stack },
-        },
-      );
-    });
-
-    it("should still send email even if user lookup fails", async () => {
-      mockGetUserRaw.mockRejectedValue(new Error("API error"));
-      const handler = getHandler(config, mockLogger);
-
-      await handler.processor(jobData);
-
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-    });
-
-    it("should continue without logger if logger is not provided", async () => {
-      mockGetUserRaw.mockResolvedValue(null);
-      const handler = getHandler(config);
-
-      // Should not throw
-      await handler.processor(jobData);
-
-      expect(mockSendEmail).toHaveBeenCalledTimes(1);
-    });
   });
 });

--- a/test/handlers/serviceNotifications/users/userUpdatedHandlerV1.test.js
+++ b/test/handlers/serviceNotifications/users/userUpdatedHandlerV1.test.js
@@ -414,4 +414,135 @@ describe("when handling userupdated_v1 job", () => {
       bullQueueTtl,
     );
   });
+
+  describe("when data contains removedServiceId (deactivation)", () => {
+    beforeEach(() => {
+      getUserRaw.mockResolvedValue({
+        sub: "user1",
+        email: "user.one-fromdir@unit.tests",
+        given_name: "John",
+        family_name: "Doe",
+        status: 1,
+      });
+    });
+
+    // Scenario 1 — Service removal triggers deactivation sync to COLLECT
+    it("should enqueue SOAP deactivation job with status 0 for COLLECT when removedServiceId matches", async () => {
+      const collectServiceId = "collect-service-id";
+      getAllApplicationRequiringNotification.mockReturnValueOnce([
+        {
+          id: collectServiceId,
+          relyingParty: { params: { receiveUserUpdates: "true" } },
+        },
+      ]);
+      const payload = {
+        sub: "user-123",
+        removedServiceId: collectServiceId,
+        removedOrgId: "org-456",
+      };
+
+      const handler = getHandler(config, logger);
+      await handler.processor(payload, jobId);
+
+      expect(mockAdd).toHaveBeenCalledTimes(1);
+      expect(mockAdd).toHaveBeenCalledWith(
+        `sendwsuserupdated_v1_${collectServiceId}`,
+        {
+          applicationId: collectServiceId,
+          user: expect.objectContaining({
+            userId: "user1",
+            status: 0,
+            organisationId: "org-456",
+          }),
+        },
+        bullQueueTtl,
+      );
+      expect(getUserServicesRaw).not.toHaveBeenCalled();
+    });
+
+    // Scenario 2 — Service removal triggers deactivation sync to S2S
+    it("should enqueue SOAP deactivation job with status 0 for S2S when removedServiceId matches", async () => {
+      const s2sServiceId = "s2s-service-id";
+      getAllApplicationRequiringNotification.mockReturnValueOnce([
+        {
+          id: s2sServiceId,
+          relyingParty: { params: { receiveUserUpdates: "true" } },
+        },
+      ]);
+      const payload = {
+        sub: "user-123",
+        removedServiceId: s2sServiceId,
+        removedOrgId: "org-456",
+      };
+
+      const handler = getHandler(config, logger);
+      await handler.processor(payload, jobId);
+
+      expect(mockAdd).toHaveBeenCalledTimes(1);
+      expect(mockAdd).toHaveBeenCalledWith(
+        `sendwsuserupdated_v1_${s2sServiceId}`,
+        {
+          applicationId: s2sServiceId,
+          user: expect.objectContaining({
+            userId: "user1",
+            status: 0,
+            organisationId: "org-456",
+          }),
+        },
+        bullQueueTtl,
+      );
+      expect(getUserServicesRaw).not.toHaveBeenCalled();
+    });
+
+    // Scenario 5 — Non-legacy service removal does not trigger SOAP sync
+    it("should not enqueue any job and not call getUserServicesRaw when removedServiceId is non-legacy", async () => {
+      getAllApplicationRequiringNotification.mockReturnValueOnce([
+        {
+          id: "some-other-legacy-service",
+          relyingParty: { params: { receiveUserUpdates: "true" } },
+        },
+      ]);
+      const payload = {
+        sub: "user-123",
+        removedServiceId: "non-legacy-service-id",
+        removedOrgId: "org-456",
+      };
+
+      const handler = getHandler(config, logger);
+      await handler.processor(payload, jobId);
+
+      expect(mockAdd).not.toHaveBeenCalled();
+      expect(getUserServicesRaw).not.toHaveBeenCalled();
+    });
+
+    // Scenario 4 — Unknown removedServiceId (app not found) does nothing and does not throw
+    it("should not enqueue any job when removedServiceId does not match any known application", async () => {
+      const payload = {
+        sub: "user-123",
+        removedServiceId: "unknown-service-id",
+        removedOrgId: "org-456",
+      };
+
+      const handler = getHandler(config, logger);
+      await expect(handler.processor(payload, jobId)).resolves.not.toThrow();
+
+      expect(mockAdd).not.toHaveBeenCalled();
+      expect(getUserServicesRaw).not.toHaveBeenCalled();
+    });
+
+    // Scenario 4/Backward compat — No removedServiceId falls through to existing getUserServicesRaw logic
+    it("should call getUserServicesRaw and not trigger the deactivation branch when removedServiceId is absent", async () => {
+      const normalPayload = {
+        sub: "user1",
+        email: "user.one@unit.tests",
+        status: 1,
+      };
+
+      const handler = getHandler(config, logger);
+      await handler.processor(normalPayload, jobId);
+
+      expect(getUserServicesRaw).toHaveBeenCalledTimes(1);
+      expect(getUserRaw).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
https://dfe-secureaccess.atlassian.net/browse/NSA-9314?atlOrigin=eyJpIjoiMjc2N2JjOWQzNjk3NGM5NWFkYzc2MjBhZWRlZTA3ZWMiLCJwIjoiaiJ9

- **`userUpdatedHandlerV1.js`**:  Added a deactivation branch at the top of `process()`. When `removedServiceId` is present in the payload (supplied by the companion `login.dfe.access` PR), the handler looks up the application via the existing `getAllApplicationRequiringNotification` filter, fetches the user via `getUserRaw`, and enqueues `sendwsuserupdated_v1_<appId>` with `status: 0` and `organisationId: removedOrgId`, then **returns early**. The `getUserServicesRaw` path only runs when `removedServiceId` is absent, preserving full backward compatibility for all other user-update events.


- **`userServiceRemovedV1.js` / `removedUserFromOrgV1.js`**: Removed the PR #322 try/catch blocks that re-enqueued `userupdated_v1` with only `{ sub }` (no `removedServiceId`). That path could never trigger a deactivation sync because the removed service is already deleted from the DB when the handler runs. Keeping it would double-fire the wrong path. Unused imports (`bullEnqueue`, `getUserRaw`) removed from both files.

## Test plan

- [ ] Unit tests added for all 5 ticket scenarios: COLLECT deactivation, S2S deactivation, non-legacy removal does nothing, unknown service ID does nothing, no `removedServiceId` falls through to existing path
- [ ] All pre-existing tests untouched - 280 tests pass across 61 suites

## Dependency

 `login.dfe.access` ** (https://github.com/DFE-Digital/login.dfe.access/pull/152) Must be deployed before this service**. Without it, `removedServiceId` will never appear in the payload and the deactivation branch will never fire.
