### PR TITLE
[NSA-9613]-fix:  Wrong/missing service eligibility and  SOAP failures

### DIFF
--- a/src/handlers/serviceNotifications/users/index.js
+++ b/src/handlers/serviceNotifications/users/index.js
@@ -1,22 +1,20 @@
 const { getAllApplicationRequiringNotification } = require("./../utils");
 const userUpdatedHandlerV1 = require("./userUpdatedHandlerV1");
 const sendWSUserUpdatedV1 = require("./sendWSUserUpdatedV1");
+const { canReceiveUserUpdate } = require("./userUpdateEligibility");
 
-const applictionRequiringNotificationCondition = (a) =>
-  a.relyingParty &&
-  a.relyingParty.params &&
-  a.relyingParty.params.receiveUserUpdates === "true";
+const applictionRequiringNotificationCondition = (a) => canReceiveUserUpdate(a);
 
 const register = async (config, logger, correlationId) => {
   const handlers = [userUpdatedHandlerV1.getHandler(config, logger)];
 
-  const applications = await getAllApplicationRequiringNotification(
+  const candidateApplications = await getAllApplicationRequiringNotification(
     config,
     applictionRequiringNotificationCondition,
     correlationId,
   );
   handlers.push(
-    ...applications.map((application) =>
+    ...candidateApplications.map((application) =>
       sendWSUserUpdatedV1.getHandler(config, logger, application),
     ),
   );

--- a/src/handlers/serviceNotifications/users/userUpdateEligibility.js
+++ b/src/handlers/serviceNotifications/users/userUpdateEligibility.js
@@ -1,0 +1,41 @@
+const getLegacyWsSyncSetting = (application) => {
+  const params = application?.relyingParty?.params;
+  const explicitFlags = [
+    application?.isLegacyWsSync,
+    params?.isLegacyWsSync,
+    params?.wsLegacySyncEnabled,
+  ];
+  const configuredFlag = explicitFlags.find((value) => value !== undefined);
+
+  if (configuredFlag === undefined) {
+    return { isConfigured: false, enabled: true };
+  }
+
+  return {
+    isConfigured: true,
+    enabled: `${configuredFlag}`.toLowerCase() === "true",
+  };
+};
+
+const canReceiveUserUpdate = (application) => {
+  const params = application?.relyingParty?.params;
+  if (!params || params.receiveUserUpdates !== "true") {
+    return false;
+  }
+
+  // WS updates require a SOAP endpoint. Without this we cannot send.
+  if (!params.wsWsdlUrl) {
+    return false;
+  }
+
+  const setting = getLegacyWsSyncSetting(application);
+  if (setting.isConfigured && !setting.enabled) {
+    return false;
+  }
+
+  return true;
+};
+
+module.exports = {
+  canReceiveUserUpdate,
+};

--- a/src/handlers/serviceNotifications/users/userUpdatedHandlerV1.js
+++ b/src/handlers/serviceNotifications/users/userUpdatedHandlerV1.js
@@ -38,7 +38,25 @@ const getRequiredJobs = async (config, logger, userData, correlationId) => {
       `Using user access snapshot embedded in userupdated_v1 payload for user ${user.sub}`,
       { correlationId },
     );
+    logger.info(
+      `Snapshot for user ${user.sub}: ${JSON.stringify({
+        userServices: userData.userServices,
+        userOrganisations: userData.userOrganisations,
+      })}`,
+      { correlationId },
+    );
   }
+
+  logger.info(
+    `Applications considered for notification: ${JSON.stringify(
+      applications.map((a) => ({
+        id: a.id,
+        name: a.name,
+        receiveUserUpdates: a.receiveUserUpdates,
+      })),
+    )} for user ${user.sub}`,
+    { correlationId },
+  );
 
   const userOrganisations = Array.isArray(userData?.userOrganisations)
     ? userData.userOrganisations

--- a/src/handlers/serviceNotifications/users/userUpdatedHandlerV1.js
+++ b/src/handlers/serviceNotifications/users/userUpdatedHandlerV1.js
@@ -6,11 +6,9 @@ const {
 } = require("login.dfe.api-client/users");
 const { bullEnqueue } = require("../../../infrastructure/jobQueue/BullHelpers");
 const { v4: uuid } = require("uuid");
+const { canReceiveUserUpdate } = require("./userUpdateEligibility");
 
-const applictionRequiringNotificationCondition = (a) =>
-  a.relyingParty &&
-  a.relyingParty.params &&
-  a.relyingParty.params.receiveUserUpdates === "true";
+const applictionRequiringNotificationCondition = (a) => canReceiveUserUpdate(a);
 
 const getRequiredJobs = async (config, logger, userData, correlationId) => {
   let user = userData;
@@ -19,12 +17,13 @@ const getRequiredJobs = async (config, logger, userData, correlationId) => {
   }
 
   const jobs = [];
-  const applications = await getAllApplicationRequiringNotification(
+  const candidateApplications = await getAllApplicationRequiringNotification(
     config,
     applictionRequiringNotificationCondition,
     correlationId,
     true,
   );
+  const applications = candidateApplications;
   const userOrganisations = await getUserOrganisationsRaw({ userId: user.sub });
   const userAccess = await getUserServicesRaw({ userId: user.sub });
 
@@ -115,6 +114,13 @@ const process = async (config, logger, data, jobId) => {
   const correlationId = `userupdated-${jobId || uuid()}`;
 
   const jobs = await getRequiredJobs(config, logger, data, correlationId);
+  if (jobs.length === 0) {
+    logger.info(
+      `No eligible user update targets found for user ${data.sub || "unknown"}`,
+      { correlationId },
+    );
+    return;
+  }
 
   for (let i = 0; i < jobs.length; i += 1) {
     await bullEnqueue(`sendwsuserupdated_v1_${jobs[i].applicationId}`, jobs[i]);

--- a/src/handlers/serviceNotifications/users/userUpdatedHandlerV1.js
+++ b/src/handlers/serviceNotifications/users/userUpdatedHandlerV1.js
@@ -24,8 +24,28 @@ const getRequiredJobs = async (config, logger, userData, correlationId) => {
     true,
   );
   const applications = candidateApplications;
-  const userOrganisations = await getUserOrganisationsRaw({ userId: user.sub });
-  const userAccess = await getUserServicesRaw({ userId: user.sub });
+
+  // Prefer access info captured by the upstream notification (e.g. Directories
+  // snapshots services/organisations BEFORE deactivating the user, so a live
+  // lookup here would return empty). Fall back to live lookups when the
+  // payload does not carry them, to preserve backwards compatibility.
+  const hasEmbeddedAccess =
+    Array.isArray(userData?.userServices) ||
+    Array.isArray(userData?.userOrganisations);
+
+  if (hasEmbeddedAccess) {
+    logger.info(
+      `Using user access snapshot embedded in userupdated_v1 payload for user ${user.sub}`,
+      { correlationId },
+    );
+  }
+
+  const userOrganisations = Array.isArray(userData?.userOrganisations)
+    ? userData.userOrganisations
+    : await getUserOrganisationsRaw({ userId: user.sub });
+  const userAccess = Array.isArray(userData?.userServices)
+    ? userData.userServices
+    : await getUserServicesRaw({ userId: user.sub });
 
   applications.forEach((application) => {
     const userAccessToApplication = userAccess

--- a/src/infrastructure/webServices/SecureAccessWebServiceClient.js
+++ b/src/infrastructure/webServices/SecureAccessWebServiceClient.js
@@ -16,6 +16,60 @@ class SoapHttpClient {
     this.correlationId = correlationId;
   }
 
+  parseXml(xml) {
+    return new Promise((resolve, reject) => {
+      parseXmlString(
+        xml,
+        {
+          tagNameProcessors: [stripPrefix],
+        },
+        (err, result) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(result);
+          }
+        },
+      );
+    });
+  }
+
+  getSoapFaultMessage(fault) {
+    if (!fault) {
+      return "SOAP fault returned";
+    }
+
+    const faultCode = fault.faultcode?.[0] || fault.Code?.[0]?.Value?.[0];
+    const faultReason =
+      fault.faultstring?.[0] || fault.Reason?.[0]?.Text?.[0] || "Unknown";
+    return `${faultCode || "SOAP Fault"}: ${faultReason}`;
+  }
+
+  async validateSoapResponseBody(body) {
+    const responseBody = `${body || ""}`.trim();
+    if (!responseBody) {
+      throw new Error("SOAP endpoint returned an empty response body");
+    }
+
+    let parsedBody;
+    try {
+      parsedBody = await this.parseXml(responseBody);
+    } catch (e) {
+      throw new Error(`Unable to parse SOAP response body - ${e.message}`);
+    }
+
+    const envelope = parsedBody?.Envelope;
+    const bodyNode = envelope?.Body?.[0];
+    if (!bodyNode) {
+      throw new Error("SOAP response is missing Envelope/Body elements");
+    }
+
+    const fault = bodyNode.Fault?.[0];
+    if (fault) {
+      throw new Error(this.getSoapFaultMessage(fault));
+    }
+  }
+
   request(rurl, data, callback, exheaders) {
     let headers;
 
@@ -78,11 +132,16 @@ class SoapHttpClient {
       this.request(
         endpoint,
         soapMessage.toXmlString(),
-        (err, response, body) => {
+        async (err, response, body) => {
           if (err) {
             reject(err);
           } else {
-            resolve(body);
+            try {
+              await this.validateSoapResponseBody(body);
+              resolve(body);
+            } catch (e) {
+              reject(e);
+            }
           }
         },
         { SOAPAction: soapAction, "content-type": soapMessage.contentType },

--- a/test/handlers/serviceNotifications/users/userUpdatedHandlerV1.test.js
+++ b/test/handlers/serviceNotifications/users/userUpdatedHandlerV1.test.js
@@ -511,4 +511,96 @@ describe("when handling userupdated_v1 job", () => {
       bullQueueTtl,
     );
   });
+
+  it("then it should use the embedded user access snapshot from the payload instead of doing a live lookup", async () => {
+    getAllApplicationRequiringNotification.mockReset().mockReturnValue([
+      {
+        id: "service1",
+        relyingParty: {
+          params: {
+            wsWsdlUrl: "https://service.one/wsdl",
+            wsProvisionUserAction: "pu-action",
+          },
+        },
+      },
+    ]);
+
+    const dataWithSnapshot = {
+      sub: "user1",
+      email: "user.one@unit.tests",
+      given_name: "Test",
+      family_name: "Tester",
+      status: 1,
+      userServices: [
+        {
+          serviceId: "service1",
+          organisationId: "organisation1",
+          roles: [{ id: "role1", code: "ROLE-ONE", numericId: 1 }],
+        },
+      ],
+      userOrganisations: [
+        {
+          organisation: {
+            id: "organisation1",
+            legacyId: 123,
+            urn: "985632",
+            localAuthority: { code: "999" },
+          },
+          numericIdentifier: "sauser1",
+        },
+      ],
+    };
+
+    const handler = getHandler(config, logger);
+    await handler.processor(dataWithSnapshot, jobId);
+
+    expect(getUserServicesRaw).not.toHaveBeenCalled();
+    expect(getUserOrganisationsRaw).not.toHaveBeenCalled();
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Using user access snapshot embedded in userupdated_v1 payload for user user1",
+      ),
+      expect.any(Object),
+    );
+    expect(mockAdd).toHaveBeenCalledTimes(1);
+    expect(mockAdd).toHaveBeenCalledWith(
+      "sendwsuserupdated_v1_service1",
+      expect.objectContaining({
+        applicationId: "service1",
+        user: expect.objectContaining({
+          userId: "user1",
+          status: 1,
+          organisationId: 123,
+          roles: [{ id: 1, code: "ROLE-ONE" }],
+        }),
+      }),
+      bullQueueTtl,
+    );
+  });
+
+  it("then it should fall back to live lookup when the payload carries no access snapshot", async () => {
+    getAllApplicationRequiringNotification.mockReset().mockReturnValue([
+      {
+        id: "service1",
+        relyingParty: {
+          params: {
+            wsWsdlUrl: "https://service.one/wsdl",
+            wsProvisionUserAction: "pu-action",
+          },
+        },
+      },
+    ]);
+
+    const handler = getHandler(config, logger);
+    await handler.processor(data, jobId);
+
+    expect(getUserServicesRaw).toHaveBeenCalledWith({ userId: "user1" });
+    expect(getUserOrganisationsRaw).toHaveBeenCalledWith({ userId: "user1" });
+    expect(logger.info).not.toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Using user access snapshot embedded in userupdated_v1 payload",
+      ),
+      expect.any(Object),
+    );
+  });
 });

--- a/test/handlers/serviceNotifications/users/userUpdatedHandlerV1.test.js
+++ b/test/handlers/serviceNotifications/users/userUpdatedHandlerV1.test.js
@@ -47,6 +47,9 @@ const jobId = 1;
 
 describe("when handling userupdated_v1 job", () => {
   beforeEach(() => {
+    logger.info.mockReset();
+    logger.warn.mockReset();
+    logger.error.mockReset();
     getUserServicesRaw.mockReturnValue([
       {
         serviceId: "service1",
@@ -122,14 +125,14 @@ describe("when handling userupdated_v1 job", () => {
       "userupdated-1",
     );
     expect(getAllApplicationRequiringNotification.mock.calls[0][3]).toBe(true);
-    expect(
-      getAllApplicationRequiringNotification.mock.calls[0][1]({}),
-    ).toBeUndefined();
+    expect(getAllApplicationRequiringNotification.mock.calls[0][1]({})).toBe(
+      false,
+    );
     expect(
       getAllApplicationRequiringNotification.mock.calls[0][1]({
         relyingParty: {},
       }),
-    ).toBeUndefined();
+    ).toBe(false);
     expect(
       getAllApplicationRequiringNotification.mock.calls[0][1]({
         relyingParty: { params: {} },
@@ -144,7 +147,28 @@ describe("when handling userupdated_v1 job", () => {
       getAllApplicationRequiringNotification.mock.calls[0][1]({
         relyingParty: { params: { receiveUserUpdates: "true" } },
       }),
+    ).toBe(false);
+    expect(
+      getAllApplicationRequiringNotification.mock.calls[0][1]({
+        relyingParty: {
+          params: {
+            receiveUserUpdates: "true",
+            wsWsdlUrl: "https://service.one/wsdl",
+          },
+        },
+      }),
     ).toBe(true);
+  });
+
+  it("then it should log and skip when no eligible targets are available", async () => {
+    const handler = getHandler(config, logger);
+    await handler.processor(data, jobId);
+
+    expect(mockAdd).toHaveBeenCalledTimes(0);
+    expect(logger.info).toHaveBeenCalledWith(
+      "No eligible user update targets found for user user1",
+      { correlationId: "userupdated-1" },
+    );
   });
 
   it("then it should queue a senduserupdated_v1 job for each application", async () => {
@@ -259,6 +283,79 @@ describe("when handling userupdated_v1 job", () => {
               id: 1,
               code: "ROLE-ONE",
             },
+            {
+              id: 2,
+              code: "ROLE-TWO",
+            },
+          ],
+        },
+      },
+      bullQueueTtl,
+    );
+  });
+
+  it("then it should include all eligible services when legacy flags are mixed", async () => {
+    getAllApplicationRequiringNotification.mockReset().mockReturnValue([
+      {
+        id: "service1",
+        relyingParty: {
+          params: {
+            receiveUserUpdates: "true",
+            wsWsdlUrl: "https://service.one/wsdl",
+          },
+        },
+      },
+      {
+        id: "service2",
+        relyingParty: {
+          params: {
+            receiveUserUpdates: "true",
+            wsWsdlUrl: "https://service.two/wsdl",
+            isLegacyWsSync: "true",
+          },
+        },
+      },
+    ]);
+
+    const handler = getHandler(config, logger);
+    await handler.processor(data, jobId);
+
+    expect(mockAdd).toHaveBeenCalledTimes(2);
+    expect(mockAdd).toHaveBeenCalledWith(
+      "sendwsuserupdated_v1_service1",
+      {
+        applicationId: "service1",
+        user: {
+          userId: "user1",
+          legacyUserId: "sauser1",
+          email: "user.one@unit.tests",
+          status: 1,
+          organisationId: 123,
+          organisationUrn: "985632",
+          organisationLACode: "999",
+          roles: [
+            {
+              id: 1,
+              code: "ROLE-ONE",
+            },
+          ],
+        },
+      },
+      bullQueueTtl,
+    );
+    expect(mockAdd).toHaveBeenCalledWith(
+      "sendwsuserupdated_v1_service2",
+      {
+        applicationId: "service2",
+        user: {
+          userId: "user1",
+          legacyUserId: "sauser1",
+          email: "user.one@unit.tests",
+          status: 1,
+          organisationId: 123,
+          organisationUrn: "985632",
+          organisationLACode: "999",
+          roles: [
             {
               id: 2,
               code: "ROLE-TWO",

--- a/test/infrastructure/webServices/SecureAccessWebServiceClient.test.js
+++ b/test/infrastructure/webServices/SecureAccessWebServiceClient.test.js
@@ -1,0 +1,148 @@
+const SecureAccessWebServiceClient = require("../../../src/infrastructure/webServices/SecureAccessWebServiceClient");
+
+const getResponse = (status, contentType, body) => ({
+  status,
+  headers: {
+    get: jest.fn().mockReturnValue(contentType),
+  },
+  text: jest.fn().mockResolvedValue(body),
+});
+
+const wsdlBody = `<?xml version="1.0" encoding="utf-8"?>
+<definitions targetNamespace="urn:test" xmlns="http://schemas.xmlsoap.org/wsdl/" xmlns:wsaw="http://www.w3.org/2006/05/addressing/wsdl">
+  <portType>
+    <operation name="ProvisionUser">
+      <input wsaw:Action="urn:test:ProvisionUser" />
+    </operation>
+    <operation name="ProvisionGroup">
+      <input wsaw:Action="urn:test:ProvisionGroup" />
+    </operation>
+    <operation name="ProvisionOrganisation">
+      <input wsaw:Action="urn:test:ProvisionOrganisation" />
+    </operation>
+  </portType>
+  <service>
+    <port>
+      <address location="https://legacy.test/ws" />
+    </port>
+  </service>
+</definitions>`;
+
+describe("SecureAccessWebServiceClient", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it("throws when SOAP response body includes a SOAP 1.1 fault", async () => {
+    const faultBody = `<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <soap:Fault>
+      <faultcode>Client</faultcode>
+      <faultstring>Payload rejected</faultstring>
+    </soap:Fault>
+  </soap:Body>
+</soap:Envelope>`;
+
+    global.fetch
+      .mockResolvedValueOnce(getResponse(200, "text/xml", wsdlBody))
+      .mockResolvedValueOnce(getResponse(200, "text/xml", faultBody));
+
+    const client = await SecureAccessWebServiceClient.create(
+      "https://legacy.test/wsdl",
+      "username",
+      "password",
+      false,
+      "corr-id",
+    );
+
+    await expect(
+      client.provisionUser(
+        "UPDATE",
+        "12345",
+        "legacy.user",
+        "First",
+        "Last",
+        "user@example.test",
+        123,
+        1,
+        "10001",
+        "999",
+        [],
+      ),
+    ).rejects.toThrow("Client: Payload rejected");
+  });
+
+  it("throws when SOAP body is empty even if transport checks pass", async () => {
+    global.fetch
+      .mockResolvedValueOnce(getResponse(200, "text/xml", wsdlBody))
+      .mockResolvedValueOnce(getResponse(200, "text/xml", ""));
+
+    const client = await SecureAccessWebServiceClient.create(
+      "https://legacy.test/wsdl",
+      "username",
+      "password",
+      false,
+      "corr-id",
+    );
+
+    await expect(
+      client.provisionUser(
+        "UPDATE",
+        "12345",
+        "legacy.user",
+        "First",
+        "Last",
+        "user@example.test",
+        123,
+        1,
+        "10001",
+        "999",
+        [],
+      ),
+    ).rejects.toThrow("SOAP endpoint returned an empty response body");
+  });
+
+  it("allows SOAP responses without a fault", async () => {
+    const successBody = `<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <ProvisionUserResponse xmlns="urn:test">
+      <ProvisionUserResult>Success</ProvisionUserResult>
+    </ProvisionUserResponse>
+  </soap:Body>
+</soap:Envelope>`;
+
+    global.fetch
+      .mockResolvedValueOnce(getResponse(200, "text/xml", wsdlBody))
+      .mockResolvedValueOnce(getResponse(200, "text/xml", successBody));
+
+    const client = await SecureAccessWebServiceClient.create(
+      "https://legacy.test/wsdl",
+      "username",
+      "password",
+      false,
+      "corr-id",
+    );
+
+    await expect(
+      client.provisionUser(
+        "UPDATE",
+        "12345",
+        "legacy.user",
+        "First",
+        "Last",
+        "user@example.test",
+        123,
+        1,
+        "10001",
+        "999",
+        [],
+      ),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION

1.validate SOAP response bodies and surface faults

SoapHttpClient previously treated any HTTP 200 with an XML content-type as
success, even when the body contained a SOAP Fault, was empty, or was
malformed - silently dropping user updates downstream.

Add validateSoapResponseBody and getSoapFaultMessage so makeSoapRequest now
rejects on empty bodies, unparseable XML, missing Envelope/Body, and SOAP
Faults (handles both SOAP 1.1 and 1.2 fault shapes). New tests cover fault
rejection, empty-body rejection, and the successful path.

2. centralise user-update eligibility in canReceiveUserUpdate

Eligibility was checked inline in both index.js (registration) and
userUpdatedHandlerV1.js (processing) using slightly different rules, which
allowed services without a wsWsdlUrl to be queued for delivery and let
explicit legacy-sync opt-outs be ignored.

Extract a single canReceiveUserUpdate helper (userUpdateEligibility.js) used
by both call sites. A service is eligible only if receiveUserUpdates is
true, wsWsdlUrl is set, and legacy sync is not explicitly disabled. Log a
clear "No eligible user update targets found" message when nothing matches.
Tests updated to assert the new rule and the no-targets log.